### PR TITLE
Update to ilivalidator 1.10.0

### DIFF
--- a/routine/README.md
+++ b/routine/README.md
@@ -47,8 +47,8 @@ gradlew -Pvendor=ig/check -Pics=pathToics.exe test
 The parameter ``-Pics`` can also be used to test different versions of iG/Check.
 
 ### Testing other versions of the ilivalidator
-The routine is preconfigured to test the ilivalidator version 1.9.3.
-To test other versions, string ``compile 'ch.interlis:ilivalidator:1.9.3'`` in the ``build.gradle`` file (under ``dependencies``) must be modified accordingly.
+The routine is preconfigured to test the ilivalidator version 1.10.0.
+To test other versions, string ``compile 'ch.interlis:ilivalidator:1.10.0'`` in the ``build.gradle`` file (under ``dependencies``) must be modified accordingly.
 
 ### Skip specific tests
 All test types are listed in the file ``build.gradle`` (under ``test``). To skip a test type, the corresponding line must be commented out.
@@ -57,13 +57,17 @@ All test types are listed in the file ``build.gradle`` (under ``test``). To skip
 Specific iG/Check settings can be set in the file ``interlis2.cfg`` in the directory ``igcheck2``.
 
 ### Tests that have been switched off directly in the code
-#### ilivalidator Version 1.9.3
+#### ilivalidator Version 1.10.0
 | Test | Reason |
 | --- | --- |
-| RCO.T01a.xtf | Crash |
-| RCO.T02b.xtf | Crash |
+| RCO.T01a.xtf | java.lang.NullPointerException |
+| RCO.T02b.xtf | Hang |
 | RHE.T01b.xtf | java.lang.IllegalArgumentException instead of java.lang.AssertionError. Error message is correct |
 | RHE.T04a.xtf | java.lang.IllegalArgumentException instead of java.lang.AssertionError. Error message is correct |
+| RKo.T08a.xtf | java.lang.NullPointerException |
+| RKo.T08b.xtf | java.lang.NullPointerException |
+| RKo.T08c.xtf | java.lang.NullPointerException |
+| RKo.T08d.xtf | java.lang.NullPointerException |
 | RTO.T02a.xtf | java.lang.IllegalArgumentException instead of java.lang.AssertionError. Error message is correct |
 | RTR.T02a.xtf | Error message is wrong |
 | RTR.T02b.xtf | Error message is wrong |

--- a/routine/README_de-CH.md
+++ b/routine/README_de-CH.md
@@ -47,8 +47,8 @@ gradlew -Pvendor=ig/check -Pics=pathToics.exe test
 Der Parameter ``-Pics`` kann zusätzlich benutzt werden, um unterschiedliche Versionen von iG/Check zu testen.
 
 ### Andere Versionen des ilivalidators testen
-Die Routine ist vorkonfiguriert um den ilivalidator Version 1.9.3 zu testen.
-Um andere Versionen des ilivalidators zu testen, muss die Information ``compile 'ch.interlis:ilivalidator:1.9.3'`` in der Datei ``build.gradle`` (unter ``dependencies``) entsprechend angepasst werden.
+Die Routine ist vorkonfiguriert um den ilivalidator Version 1.10.0 zu testen.
+Um andere Versionen des ilivalidators zu testen, muss die Information ``compile 'ch.interlis:ilivalidator:1.10.0'`` in der Datei ``build.gradle`` (unter ``dependencies``) entsprechend angepasst werden.
 
 ### Spezifische Tests ausschalten
 Alle Test-Typen der Routine sind in der Datei ``build.gradle`` (unter ``test``) gelistet. Um einen Test-Typ auszuschalten, muss die entsprechende Linie auskommentiert werden.
@@ -57,13 +57,17 @@ Alle Test-Typen der Routine sind in der Datei ``build.gradle`` (unter ``test``) 
 Spezifische iG/Check-Einstellungen können zusätzlich in der Datei ``interlis2.cfg`` im Verzeichnis ``igcheck2`` gesetzt werden.
 
 ### Tests, die direkt im Code ausgeschaltet worden sind
-#### ilivalidator Version 1.9.3
+#### ilivalidator Version 1.10.0
 | Test | Begründung |
 | --- | --- |
 | RCO.T01a.xtf | Absturz |
 | RCO.T02b.xtf | Absturz |
 | RHE.T01b.xtf | java.lang.IllegalArgumentException statt java.lang.AssertionError. Fehlermeldung ist korrekt |
 | RHE.T04a.xtf | java.lang.IllegalArgumentException statt java.lang.AssertionError. Fehlermeldung ist korrekt |
+| RKo.T08a.xtf | java.lang.NullPointerException |
+| RKo.T08b.xtf | java.lang.NullPointerException |
+| RKo.T08c.xtf | java.lang.NullPointerException |
+| RKo.T08d.xtf | java.lang.NullPointerException |
 | RTO.T02a.xtf | java.lang.IllegalArgumentException statt java.lang.AssertionError. Fehlermeldung ist korrekt |
 | RTR.T02a.xtf | Falsche Fehlermeldung |
 | RTR.T02b.xtf | Falsche Fehlermeldung |

--- a/routine/README_de-CH.md
+++ b/routine/README_de-CH.md
@@ -60,7 +60,7 @@ Spezifische iG/Check-Einstellungen können zusätzlich in der Datei ``interlis2.
 #### ilivalidator Version 1.10.0
 | Test | Begründung |
 | --- | --- |
-| RCO.T01a.xtf | Absturz |
+| RCO.T01a.xtf | java.lang.NullPointerException |
 | RCO.T02b.xtf | Absturz |
 | RHE.T01b.xtf | java.lang.IllegalArgumentException statt java.lang.AssertionError. Fehlermeldung ist korrekt |
 | RHE.T04a.xtf | java.lang.IllegalArgumentException statt java.lang.AssertionError. Fehlermeldung ist korrekt |

--- a/routine/build.gradle
+++ b/routine/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'java'
 dependencies {
     compile 'org.apache.commons:commons-math3:3.6.1'
     compile 'com.google.guava:guava:23.0'
-    compile 'ch.interlis:ilivalidator:1.9.3'
+    compile 'ch.interlis:ilivalidator:1.10.0'
     compile 'ch.qos.logback:logback-classic:1.2.3'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/routine/src/test/java/ch/interlis/testsuite/ConstraintTest.java
+++ b/routine/src/test/java/ch/interlis/testsuite/ConstraintTest.java
@@ -445,6 +445,8 @@ public class ConstraintTest {
  	 */
 	@Test
 	public void RKo_T08a() {
+		// Ignored if vendor="ilivalidator" --> Crash Error: java.lang.NullPointerException
+		assumeFalse (System.getProperty("vendor").equals("ilivalidator"));
 		boolean ret = TestUtil.runJob(vendor, "../data/RKo.T08a.xtf");
 		logger.info(vendor + " - " + testName.getMethodName() +": " + ret);
 		assertFalse(ret);
@@ -465,6 +467,8 @@ public class ConstraintTest {
  	 */
 	@Test
 	public void RKo_T08b() {
+		// Ignored if vendor="ilivalidator" --> Crash Error: java.lang.NullPointerException
+		assumeFalse (System.getProperty("vendor").equals("ilivalidator"));
 		boolean ret = TestUtil.runJob(vendor, "../data/RKo.T08b.xtf");
 		logger.info(vendor + " - " + testName.getMethodName() +": " + ret);
 		assertTrue(ret);
@@ -485,6 +489,8 @@ public class ConstraintTest {
  	 */
 	@Test
 	public void RKo_T08c() {
+		// Ignored if vendor="ilivalidator" --> Crash Error: java.lang.NullPointerException
+		assumeFalse (System.getProperty("vendor").equals("ilivalidator"));
 		boolean ret = TestUtil.runJob(vendor, "../data/RKo.T08c.xtf");
 		logger.info(vendor + " - " + testName.getMethodName() +": " + ret);
 		assertTrue(ret);
@@ -505,6 +511,8 @@ public class ConstraintTest {
  	 */
 	@Test
 	public void RKo_T08d() {
+		// Ignored if vendor="ilivalidator" --> Crash Error: java.lang.NullPointerException
+		assumeFalse (System.getProperty("vendor").equals("ilivalidator"));
 		boolean ret = TestUtil.runJob(vendor, "../data/RKo.T08d.xtf");
 		logger.info(vendor + " - " + testName.getMethodName() +": " + ret);
 		assertFalse(ret);


### PR DESCRIPTION
Fix tests for STANDARDOID according to annex D of the INTERLIS Manual