### PR TITLE
New numeric attribute test RAt.T09h

### DIFF
--- a/data/RAt.T09h.xtf
+++ b/data/RAt.T09h.xtf
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- RAt.T09d -->
+<TRANSFER xmlns="http://www.interlis.ch/INTERLIS2.3">
+  <HEADERSECTION VERSION="2.3" SENDER="ili2c-4.5.22-20160520">
+    <MODELS>
+      <MODEL NAME="TestSuite" VERSION="2018-10-10" URI="http://www.kogis.ch"/>
+	  <MODEL NAME="TestSuite2" VERSION="2018-10-10" URI="http://www.kogis.ch"/>
+    </MODELS>
+  </HEADERSECTION>
+  <DATASECTION>
+    <TestSuite.Bodenbedeckung BID="a">
+		<TestSuite.Bodenbedeckung.GebaeudeArt TID="ga4">
+			<Art>12345</Art>
+		</TestSuite.Bodenbedeckung.GebaeudeArt>
+		<TestSuite.Bodenbedeckung.Gebaeude  TID="g10">
+			<!-- INTERLIS Referenzhandbuch Kap. 3.3.11.4 Zahlen können auch mit höherer Genauigkeit transferiert werden als durch den Wertebereich verlangt. -->
+			<stoecke>2.7</stoecke>
+			<Art REF="ga4"></Art>
+		</TestSuite.Bodenbedeckung.Gebaeude>
+		<TestSuite.Bodenbedeckung.BoFlaechen TID="ok200">
+			<Flaeche>10</Flaeche>
+		</TestSuite.Bodenbedeckung.BoFlaechen>
+    </TestSuite.Bodenbedeckung>
+  </DATASECTION>
+</TRANSFER>

--- a/doc/attributes.md
+++ b/doc/attributes.md
@@ -86,8 +86,8 @@
 |:--|:--
 |**Designation**|**Attributes:** ```NumericType```
 |**Description**|The tests must check whether the attribute value satisfies the definition for ```NumericType``` in the INTERLIS data model and the corresponding encoding rules
-|**Test requirement**|[RAt.T09a.xtf](../data/RAt.T09a.xtf), [RAt.T09b.xtf](../data/RAt.T09b.xtf), [RAt.T09c.xtf](../data/RAt.T09c.xtf), [RAt.T09d.xtf](../data/RAt.T09d.xtf), [RAt.T09e.xtf](../data/RAt.T09e.xtf), [RAt.T09f.xtf](../data/RAt.T09f.xtf), [RAt.T09g.xtf](../data/RAt.T09g.xtf)
-|**Expected result**|<ul><li>RAt.T09a.xtf: no error message</li><li>RAt.T09b.xtf: error message. Invalid value (``0.9``)</li><li>RAt.T09c.xtf: no error message</li><li>RAt.T09d.xtf: error message (``00004`` instead of ``4``)</li><li>RAt.T09e.xtf: no error message (``10000.1`` will be rounded to ``10000.0``)</li><li>RAt.T09f.xtf: no error message</li><li>RAt.T09g.xtf: error message (``10000.05`` will be rounded to ``10000.1``)</li></ul>
+|**Test requirement**|[RAt.T09a.xtf](../data/RAt.T09a.xtf), [RAt.T09b.xtf](../data/RAt.T09b.xtf), [RAt.T09c.xtf](../data/RAt.T09c.xtf), [RAt.T09d.xtf](../data/RAt.T09d.xtf), [RAt.T09e.xtf](../data/RAt.T09e.xtf), [RAt.T09f.xtf](../data/RAt.T09f.xtf), [RAt.T09g.xtf](../data/RAt.T09g.xtf), [RAt.T09h.xtf](../data/RAt.T09h.xtf)
+|**Expected result**|<ul><li>RAt.T09a.xtf: no error message</li><li>RAt.T09b.xtf: error message. Invalid value (``0.9``)</li><li>RAt.T09c.xtf: no error message</li><li>RAt.T09d.xtf: error message (``00004`` instead of ``4``)</li><li>RAt.T09e.xtf: no error message (``10000.1`` will be rounded to ``10000.0``)</li><li>RAt.T09f.xtf: no error message</li><li>RAt.T09g.xtf: error message (``10000.05`` will be rounded to ``10000.1``)</li><li>RAt.T09h.xtf: no error message</li></ul>
 |**Reference**|[[1]] Chap. 2.6, 2.8.5 and 3.3.11.4
 
 ###### Attributes - RAt.T10

--- a/doc/de/attribute.adoc
+++ b/doc/de/attribute.adoc
@@ -157,6 +157,7 @@ link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T
 link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09e.xtf[RAt.T09e.xtf],
 link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09f.xtf[RAt.T09f.xtf],
 link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09g.xtf[RAt.T09g.xtf],
+link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09h.xtf[RAt.T09h.xtf],
 |*Erwartetes Ergebnis*|
 * RAt.T09a.xtf: keine Fehlermeldung
 * RAt.T09b.xtf: Fehlermeldung. Unzulässiger Wert (`0.9`)
@@ -165,6 +166,7 @@ link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T
 * RAt.T09e.xtf: keine Fehlermeldung (`10000.1` wird auf `10000.0` gerundet)
 * RAt.T09f.xtf: keine Fehlermeldung
 * RAt.T09g.xtf: Fehlermeldung (`10000.05` wird auf `10000.1` gerundet)
+* RAt.T09h.xtf: keine Fehlermeldung
 |*Referenz*|<<referenzen.adoc#1,[1]>> Kap. 2.6, 2.8.5 und 3.3.11.4
 |===
 

--- a/doc/de/attribute.adoc
+++ b/doc/de/attribute.adoc
@@ -157,7 +157,7 @@ link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T
 link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09e.xtf[RAt.T09e.xtf],
 link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09f.xtf[RAt.T09f.xtf],
 link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09g.xtf[RAt.T09g.xtf],
-link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09h.xtf[RAt.T09h.xtf],
+link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09h.xtf[RAt.T09h.xtf]
 |*Erwartetes Ergebnis*|
 * RAt.T09a.xtf: keine Fehlermeldung
 * RAt.T09b.xtf: Fehlermeldung. Unzulässiger Wert (`0.9`)

--- a/doc/fr/attributs.adoc
+++ b/doc/fr/attributs.adoc
@@ -157,6 +157,7 @@ link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T
 link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09e.xtf[RAt.T09e.xtf],
 link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09f.xtf[RAt.T09f.xtf],
 link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09g.xtf[RAt.T09g.xtf],
+link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09h.xtf[RAt.T09h.xtf],
 |*Résultat attendu*|
 * RAt.T09a.xtf: aucun message d'erreur
 * RAt.T09b.xtf: message d'erreur. Valeur non valide (`0.9`)
@@ -165,6 +166,7 @@ link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T
 * RAt.T09e.xtf: aucun message d'erreur (`10000.1` est arrondi à `10000.0`)
 * RAt.T09f.xtf: aucun message d'erreur
 * RAt.T09g.xtf: message d'erreur (`10000.05` est arrondi à `10000.1`)
+* RAt.T09h.xtf: aucun message d'erreur
 |*Référence*|<<references.adoc#1,[1]>> Chap. 2.6, 2.8.5 et 3.3.11.4
 |===
 

--- a/doc/fr/attributs.adoc
+++ b/doc/fr/attributs.adoc
@@ -157,7 +157,7 @@ link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T
 link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09e.xtf[RAt.T09e.xtf],
 link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09f.xtf[RAt.T09f.xtf],
 link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09g.xtf[RAt.T09g.xtf],
-link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09h.xtf[RAt.T09h.xtf],
+link:https://raw.githubusercontent.com/geoadmin/suite-interlis/master/data/RAt.T09h.xtf[RAt.T09h.xtf]
 |*Résultat attendu*|
 * RAt.T09a.xtf: aucun message d'erreur
 * RAt.T09b.xtf: message d'erreur. Valeur non valide (`0.9`)

--- a/routine/src/test/java/ch/interlis/testsuite/AttributeTest.java
+++ b/routine/src/test/java/ch/interlis/testsuite/AttributeTest.java
@@ -540,6 +540,26 @@ public class AttributeTest {
 	}
 
 	/**
+	 * @ID RAt.T09h
+	 *
+	 * @Designation Attributes: NumericType
+	 *
+	 * @Description The tests must check whether the attribute value satisfies the definition for NumericType in the INTERLIS data model and the corresponding encoding rules
+	 *
+	 * @Test-requirement RAt.T09h.xtf
+	 *
+	 * @Expected-result No error message
+	 *
+	 * @Reference <p><a href="https://www.interlis.ch/download/interlis2/ili2-refman_2006-04-13_e.pdf">INTERLIS Version 2 – Reference Manual</a> Chap. 2.6, 2.8.5 and 3.3.11.4</p>
+	 */
+	@Test
+	public void RAt_T09h() {
+		boolean ret = TestUtil.runJob(vendor, "../data/RAt.T09h.xtf");
+		logger.info(vendor + " - " + testName.getMethodName() +": " + ret);
+		assertTrue(ret);
+	}
+
+	/**
 	 * @ID RAt.T10a
 	 *
 	 * @Designation Attributes: FormattedType


### PR DESCRIPTION
According to the RefHB scale of a numeric datatype should be ignored when transfering numbers (see also here claeis/ilivalidator#229). I added an additional test to check this behavior with the two software packages.

Test results:
ig/check - failed
ilivalidator - passed

resolves #31 