### PR TITLE
validate vendor property

### DIFF
--- a/routine/build.gradle
+++ b/routine/build.gradle
@@ -21,6 +21,9 @@ test {
   // -Pics=c:\igcheck2\system\bin\ics.exe   # if ics.exe is not on the PATH
   systemProperty "ics",findProperty("ics")?:"ics"
 
+  if (!(project.vendor.equalsIgnoreCase("ilivalidator") || project.vendor.equalsIgnoreCase("ig/check"))) {
+      throw new GradleException('no valid <vendor> property provided. Please use "ig/check" or "ilivalidator".')
+  }
   //exclude '**/AssociationTest.class'
   //exclude '**/AttributeTest.class'
   //exclude '**/CardinalityAssociationTest.class'

--- a/routine/src/main/java/ch/interlis/testsuite/util/TestUtil.java
+++ b/routine/src/main/java/ch/interlis/testsuite/util/TestUtil.java
@@ -47,13 +47,16 @@ public class TestUtil {
                     return false;
                 }
                 return true;
-    		} else {
+    		} else if (vendor.equalsIgnoreCase("ilivalidator")){
     			Settings settings = new Settings();
     			settings.setValue(Validator.SETTING_ILIDIRS, "../data/models/");
 
     			boolean ret=Validator.runValidation(xtf, settings);
     			return ret;
-    		}
+    		} else {
+    		    System.err.println("no valid <vendor> property provided. Please use 'ig/check' or 'ilivalidator'");
+    		    return false;
+            }
     }
     private static void appendProcessOutputToStdStreams(Process p, StringBuffer stderr, StringBuffer stdout){
         BufferedReader stdInput = new BufferedReader(new InputStreamReader(p.getInputStream()));


### PR DESCRIPTION
Added improvement:
validate <vendor> property provided on command line.

Reason:
As test skipping is dependent on the correct spelling of this property we should make sure that only valid property values can be passed to the tests.

